### PR TITLE
Allow Guid as a route parameter

### DIFF
--- a/TypeGap/GapApiGenerator.cs
+++ b/TypeGap/GapApiGenerator.cs
@@ -498,6 +498,8 @@ namespace TypeGap
                 {
                     case TypeCode.DateTime:
                     case TypeCode.Object:
+                        if (get.ParameterType == typeof(Guid))
+                            break;
                         throw new Exception($"In action '{action.ActionName}' parameter type '{get.ParameterType.Name}' is not suitable " +
                                             $"as a route parameter for template '{template}'. (Type code: {typeCode})");
                 }


### PR DESCRIPTION
This check is triggered by a Guid route parameter even though Guid route parameters work fine (tested in ASP Core 3.1)